### PR TITLE
fix unwanted submit of form

### DIFF
--- a/src/app/material-file-upload/material-file-upload.component.html
+++ b/src/app/material-file-upload/material-file-upload.component.html
@@ -1,4 +1,4 @@
-<button mat-button color="warn" (click)="onClick()">
+<button mat-button color="warn" (click)="onClick()" type="button">
   <mat-icon>file_upload</mat-icon>
   {{text}}
 </button>


### PR DESCRIPTION
Fix unwanted submit if file upload is used inside form.
If you don't specify type attribute, the default  behavior of the tag <button> is submit, so you have to specify type="button" for your "upload" button.